### PR TITLE
75 hours chart

### DIFF
--- a/app/components/InfoGraphic.tsx
+++ b/app/components/InfoGraphic.tsx
@@ -59,7 +59,7 @@ function InfoGraphic({
           } text-white items-center gap-2 justify-center bg-restore-pink aspect-square rounded-full`}
         >
           <div>{text1}</div>
-          <div className="text-[64px] lg:text-[128px] font-bold" ref={ref}>
+          <div className="text-[64px] lg:text-[100px] font-bold" ref={ref}>
             {count}
           </div>
           <div>{text2}</div>

--- a/app/components/charts/BarChart.tsx
+++ b/app/components/charts/BarChart.tsx
@@ -9,10 +9,11 @@ interface BasicBarsProps {
 export default function BasicBars({ data }: BasicBarsProps) {
   return (
     <BarChart
-      xAxis={[{ scaleType: "band", data: ["2023", "2024"] }]}
+      xAxis={[{ scaleType: "band", data: ["2023", "2024", "2025"] }]}
       series={[
         {
           data: [
+            data?.volunteerHoursWorked2023 ?? 0,
             data?.volunteerHoursWorkedLastYear ?? 0,
             data?.volunteerHoursWorkedThisYear ?? 0,
           ],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,7 +115,7 @@ export default async function Home() {
           isLeftLayout={true}
           content={<BasicBars data={researchData} />}
           data={researchData.totalVoluntaryHours}
-          text1={"So far we have worked"}
+          text1={"Since 2022, we have counted"}
           text2={"voluntary hours"}
         />
 
@@ -126,7 +126,7 @@ export default async function Home() {
           content="We have opening days in the beginning of semester, when you can come and 
           pick up furniture you need for free. Check our opening dates on our social media channels.
           If you’ve got items you don’t need anymore but are too good to throw away, bring them to ReStore! 
-          We also do pick up for heavy or big items for free. Check our FAQ for more information."
+          Check our FAQ for more information."
         />
         <InfoGraphic
           isLeftLayout={false}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,8 +123,8 @@ export default async function Home() {
           leftImage={undefined}
           rightImage={someImage3}
           title="From Students, for Students"
-          content="We have opening days in the beginning of semester, when you can come and 
-          pick up furniture you need for free. Check our opening dates on our social media channels.
+          content="We have opening days, usually at the beginning of the semester, when you can come and 
+          pick up the furniture you need for free. Check our opening dates on our social media channels.
           If you’ve got items you don’t need anymore but are too good to throw away, bring them to ReStore! 
           Check our FAQ for more information."
         />

--- a/app/utils/queries.ts
+++ b/app/utils/queries.ts
@@ -44,6 +44,7 @@ export const GET_RESEARCH_DATA_QUERY = gql`
       id
       numbeOfVolunteers
       savedCo2InTons
+      volunteerHoursWorked2023
       volunteerHoursWorkedLastYear
       volunteerHoursWorkedThisYear
       totalVoluntaryHours

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -25,6 +25,7 @@ export interface ResearchData {
   savedCo2InTons?: number;
   volunteerHoursWorkedLastYear?: number;
   volunteerHoursWorkedThisYear?: number;
+  volunteerHoursWorked2023?: number;
   totalVoluntaryHours?: number;
 }
 


### PR DESCRIPTION
### What has changed?

1.  A new bar has been added to the bar chart, allowing it to display hours for the past three years.

- How it was
![image](https://github.com/user-attachments/assets/c9b94f1e-24fd-46de-bdc6-e4f59f386196)

- With the Newly Added Bar:
![image](https://github.com/user-attachments/assets/154df2ad-8a12-4531-9c85-785b5b61da6e)

2. Text Update
- The explanation for hours counting has been updated to clarify that the counting starts from the 2022 reference year.
- The "Free Pickup Service" has been removed from the "From Students, For Students" section on the landing page.